### PR TITLE
fix(server): CORS header matching

### DIFF
--- a/packages/server/src/middleware/with-cors.test.ts
+++ b/packages/server/src/middleware/with-cors.test.ts
@@ -91,9 +91,7 @@ describe('withCors()', () => {
     await withCorsRegExp(
       mockContext(endpointUrl, {
         origin: 'http://localhost:3000',
-        'content-type': 'some-type',
-        'content-encoding': 'some-encoding',
-        'accept-language': 'some-language',
+        'access-control-request-headers': 'content-type, content-encoding, accept-language',
       }),
       async (context) => {
         assertHeaders(context, 'http://localhost:3000', 'content-type, content-encoding');
@@ -109,10 +107,10 @@ describe('withCors()', () => {
   });
 
   it('should show proper methods', async () => {
-    await withCors({ allowedMethods: ['GET', 'OPTIONS'] })(
+    await withCors({ allowedMethods: ['GET', 'DELETE'] })(
       mockContext(endpointUrl),
       async (context) => {
-        assertHeaders(context, 'https://localhost', undefined, 'GET, OPTIONS');
+        assertHeaders(context, 'https://localhost', undefined, 'GET, DELETE');
       }
     );
   });

--- a/packages/server/src/middleware/with-cors.ts
+++ b/packages/server/src/middleware/with-cors.ts
@@ -37,11 +37,9 @@ export default function withCors<
     return allowedOrigin.test(origin) ? origin : undefined;
   };
 
-  const matchHeaders = (headers: IncomingHttpHeaders) => {
+  const matchHeaders = (requestHeaders: string[]) => {
     if (allowedHeaders instanceof RegExp) {
-      return Object.keys(headers)
-        .filter((value) => allowedHeaders.test(value))
-        .join(', ');
+      return requestHeaders.filter((value) => allowedHeaders.test(value)).join(', ');
     }
 
     return Array.isArray(allowedHeaders) ? allowedHeaders.join(', ') : allowedHeaders;
@@ -58,7 +56,9 @@ export default function withCors<
       headers: {
         ...context.headers,
         ...(allowOrigin && { 'access-control-allow-origin': allowOrigin }),
-        'access-control-allow-headers': matchHeaders(headers),
+        'access-control-allow-headers': matchHeaders(
+          headers['access-control-request-headers']?.split(',').map((value) => value.trim()) ?? []
+        ),
         'access-control-allow-methods': allowMethods,
         'access-control-max-age': maxAge,
       },


### PR DESCRIPTION
use `access-control-request-headers` for CORS header matching per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)