### PR TITLE
fix(server): improved `.extend()` type inferring

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "c8": "^7.12.0",
     "husky": "^8.0.2",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,10 +36,10 @@
     "c8": "^7.12.0",
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "sinon": "^14.0.2",
     "tap-arc": "^0.3.5",
-    "typescript": "^4.9.3",
+    "typescript": "^4.9.5",
     "zod": "^3.19.1"
   },
   "eslintConfig": {

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -18,8 +18,8 @@
     "@types/node": "^18.11.9",
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
-    "prettier": "^2.7.1",
-    "typescript": "^4.9.3"
+    "prettier": "^2.8.4",
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "extends": "@silverhand"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -37,10 +37,10 @@
     "c8": "^7.12.0",
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "sinon": "^14.0.2",
     "tap-arc": "^0.3.5",
-    "typescript": "^4.9.3",
+    "typescript": "^4.9.5",
     "zod": "^3.19.1"
   },
   "peerDependencies": {

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -20,8 +20,8 @@
     "@types/node": "^18.11.9",
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
-    "prettier": "^2.7.1",
-    "typescript": "^4.9.3"
+    "prettier": "^2.8.4",
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "extends": "@silverhand"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,11 +41,11 @@
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
     "openapi-schema-validator": "^12.0.2",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "sinon": "^14.0.2",
     "supertest": "^6.3.2",
     "tap-arc": "^0.3.5",
-    "typescript": "^4.9.3",
+    "typescript": "^4.9.5",
     "zod": "^3.19.1"
   },
   "eslintConfig": {

--- a/packages/server/src/model/index.test.ts
+++ b/packages/server/src/model/index.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import { z, ZodError } from 'zod';
 
+import type { InferModelType } from './index.js';
 import Model from './index.js';
 
 describe('Model class', () => {
@@ -24,13 +25,15 @@ describe('Model class', () => {
     .extend('num', { default: () => [1, 2, 3], readonly: true })
     .extend('test', { default: [2, 3, 4] });
 
+  type Forms = InferModelType<typeof forms>;
+
   it('should construct proper class', () => {
     const baseData = {
       id: 'foo',
       headers: {},
       data: { foo: 'foo', bar: 1 },
       data2: null,
-    };
+    } satisfies Partial<Forms>;
 
     assert.deepStrictEqual(forms.rawKeys, {
       id: 'id',

--- a/packages/server/src/model/index.ts
+++ b/packages/server/src/model/index.ts
@@ -73,19 +73,39 @@ export default class Model<
   extend<Key extends string & keyof ModelType, Type>(
     key: Key,
     parser: Parser<Type>
-  ): Model<Table, ModelType & { [key in Key]: Type }, DefaultKeys, ReadonlyKeys>;
+  ): Model<
+    Table,
+    { [key in keyof ModelType]: key extends Key ? Type : ModelType[key] },
+    DefaultKeys,
+    ReadonlyKeys
+  >;
   extend<Key extends string & keyof ModelType, Type>(
     key: Key,
     config: ModelExtendConfigWithDefault<Type>
-  ): Model<Table, ModelType & { [key in Key]: Type }, DefaultKeys | Key, ReadonlyKeys>;
+  ): Model<
+    Table,
+    { [key in keyof ModelType]: key extends Key ? Type : ModelType[key] },
+    DefaultKeys | Key,
+    ReadonlyKeys
+  >;
   extend<Key extends string & keyof ModelType, Type, RO extends boolean>(
     key: Key,
     config: ModelExtendConfigWithDefault<Type, true>
-  ): Model<Table, ModelType & { [key in Key]: Type }, DefaultKeys | Key, ReadonlyKeys | Key>;
+  ): Model<
+    Table,
+    { [key in keyof ModelType]: key extends Key ? Type : ModelType[key] },
+    DefaultKeys | Key,
+    ReadonlyKeys | Key
+  >;
   extend<Key extends string & keyof ModelType, Type, RO extends boolean>(
     key: Key,
     config: Parser<Type> | ModelExtendConfigWithDefault<Type, RO>
-  ): Model<Table, ModelType & { [key in Key]: Type }, DefaultKeys | Key, ReadonlyKeys> {
+  ): Model<
+    Table,
+    { [key in keyof ModelType]: key extends Key ? Type : ModelType[key] },
+    DefaultKeys | Key,
+    ReadonlyKeys
+  > {
     return new Model(
       this.raw,
       Object.freeze({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,10 +35,10 @@
     "@types/sinon": "^10.0.13",
     "eslint": "^8.28.0",
     "lint-staged": "^13.0.4",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "sinon": "^14.0.2",
     "tap-arc": "^0.3.5",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "extends": "@silverhand"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ importers:
     specifiers:
       c8: ^7.12.0
       husky: ^8.0.2
-      typescript: ^4.9.3
+      typescript: ^4.9.5
     devDependencies:
       c8: 7.12.0
       husky: 8.0.2
-      typescript: 4.9.3
+      typescript: 4.9.5
 
   packages/client:
     specifiers:
@@ -23,26 +23,26 @@ importers:
       c8: ^7.12.0
       eslint: ^8.28.0
       lint-staged: ^13.0.4
-      prettier: ^2.7.1
+      prettier: ^2.8.4
       sinon: ^14.0.2
       tap-arc: ^0.3.5
-      typescript: ^4.9.3
+      typescript: ^4.9.5
       zod: ^3.19.1
     dependencies:
       '@withtyped/server': link:../server
       '@withtyped/shared': link:../shared
     devDependencies:
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/node': 18.11.9
       '@types/sinon': 10.0.13
       c8: 7.12.0
       eslint: 8.28.0
       lint-staged: 13.0.4
-      prettier: 2.7.1
+      prettier: 2.8.4
       sinon: 14.0.2
       tap-arc: 0.3.5
-      typescript: 4.9.3
+      typescript: 4.9.5
       zod: 3.19.1
 
   packages/integration-test:
@@ -59,8 +59,8 @@ importers:
       lint-staged: ^13.0.4
       nanoid: ^4.0.0
       openapi-schema-validator: ^12.0.2
-      prettier: ^2.7.1
-      typescript: ^4.9.3
+      prettier: ^2.8.4
+      typescript: ^4.9.5
       zod: ^3.19.1
     dependencies:
       '@faker-js/faker': 7.6.0
@@ -72,13 +72,13 @@ importers:
       openapi-schema-validator: 12.0.2
       zod: 3.19.1
     devDependencies:
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/node': 18.11.9
       eslint: 8.28.0
       lint-staged: 13.0.4
-      prettier: 2.7.1
-      typescript: 4.9.3
+      prettier: 2.8.4
+      typescript: 4.9.5
 
   packages/postgres:
     specifiers:
@@ -93,28 +93,28 @@ importers:
       eslint: ^8.28.0
       lint-staged: ^13.0.4
       pg: ^8.8.0
-      prettier: ^2.7.1
+      prettier: ^2.8.4
       sinon: ^14.0.2
       tap-arc: ^0.3.5
-      typescript: ^4.9.3
+      typescript: ^4.9.5
       zod: ^3.19.1
     dependencies:
       '@types/pg': 8.6.5
       '@withtyped/shared': link:../shared
       pg: 8.8.0
     devDependencies:
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/node': 18.11.9
       '@types/sinon': 10.0.13
       '@withtyped/server': link:../server
       c8: 7.12.0
       eslint: 8.28.0
       lint-staged: 13.0.4
-      prettier: 2.7.1
+      prettier: 2.8.4
       sinon: 14.0.2
       tap-arc: 0.3.5
-      typescript: 4.9.3
+      typescript: 4.9.5
       zod: 3.19.1
 
   packages/sample:
@@ -129,9 +129,9 @@ importers:
       eslint: ^8.28.0
       lint-staged: ^13.0.4
       nanoid: ^4.0.0
-      prettier: ^2.7.1
+      prettier: ^2.8.4
       slonik: ^32.0.0
-      typescript: ^4.9.3
+      typescript: ^4.9.5
       zod: ^3.19.1
     dependencies:
       '@silverhand/essentials': 1.3.0
@@ -142,13 +142,13 @@ importers:
       slonik: 32.0.0
       zod: 3.19.1
     devDependencies:
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/node': 18.11.9
       eslint: 8.28.0
       lint-staged: 13.0.4
-      prettier: 2.7.1
-      typescript: 4.9.3
+      prettier: 2.8.4
+      typescript: 4.9.5
 
   packages/server:
     specifiers:
@@ -165,19 +165,19 @@ importers:
       eslint: ^8.28.0
       lint-staged: ^13.0.4
       openapi-schema-validator: ^12.0.2
-      prettier: ^2.7.1
+      prettier: ^2.8.4
       sinon: ^14.0.2
       supertest: ^6.3.2
       tap-arc: ^0.3.5
-      typescript: ^4.9.3
+      typescript: ^4.9.5
       zod: ^3.19.1
     dependencies:
       '@withtyped/shared': link:../shared
     devDependencies:
       '@faker-js/faker': 7.6.0
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
       '@silverhand/essentials': 1.3.0
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/koa': 2.13.5
       '@types/node': 18.11.9
       '@types/sinon': 10.0.13
@@ -186,11 +186,11 @@ importers:
       eslint: 8.28.0
       lint-staged: 13.0.4
       openapi-schema-validator: 12.0.2
-      prettier: 2.7.1
+      prettier: 2.8.4
       sinon: 14.0.2
       supertest: 6.3.2
       tap-arc: 0.3.5
-      typescript: 4.9.3
+      typescript: 4.9.5
       zod: 3.19.1
 
   packages/shared:
@@ -201,21 +201,21 @@ importers:
       '@types/sinon': ^10.0.13
       eslint: ^8.28.0
       lint-staged: ^13.0.4
-      prettier: ^2.7.1
+      prettier: ^2.8.4
       sinon: ^14.0.2
       tap-arc: ^0.3.5
-      typescript: ^4.9.3
+      typescript: ^4.9.5
     devDependencies:
-      '@silverhand/eslint-config': 1.3.0_lodna2kqutudccklmsddzyjx3a
-      '@silverhand/ts-config': 1.2.1_typescript@4.9.3
+      '@silverhand/eslint-config': 1.3.0_amdpr7nu3dr3td3nbvtvqs2bti
+      '@silverhand/ts-config': 1.2.1_typescript@4.9.5
       '@types/node': 18.11.9
       '@types/sinon': 10.0.13
       eslint: 8.28.0
       lint-staged: 13.0.4
-      prettier: 2.7.1
+      prettier: 2.8.4
       sinon: 14.0.2
       tap-arc: 0.3.5
-      typescript: 4.9.3
+      typescript: 4.9.5
 
 packages:
 
@@ -339,7 +339,7 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /@silverhand/eslint-config/1.3.0_lodna2kqutudccklmsddzyjx3a:
+  /@silverhand/eslint-config/1.3.0_amdpr7nu3dr3td3nbvtvqs2bti:
     resolution: {integrity: sha512-0+SXJXAkUe1pg2DNn3JCEo99Weev07chQsL2iSCramXeMKjEk1R1UKjgQJM9saUGF7ovY4hlE/JjFD3PFId4DQ==}
     engines: {node: ^16.0.0 || ^18.0.0}
     peerDependencies:
@@ -347,24 +347,24 @@ packages:
       prettier: ^2.7.1
     dependencies:
       '@silverhand/eslint-plugin-fp': 2.5.0_eslint@8.28.0
-      '@typescript-eslint/eslint-plugin': 5.40.1_5foadabyhuofbj4bdrxjdavre4
-      '@typescript-eslint/parser': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/eslint-plugin': 5.40.1_fscm445b3jy5afr2mxu53wdtbu
+      '@typescript-eslint/parser': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       eslint: 8.28.0
       eslint-config-prettier: 8.5.0_eslint@8.28.0
       eslint-config-xo: 0.42.0_eslint@8.28.0
-      eslint-config-xo-typescript: 0.53.0_hfd344ics4i2ms5ixiwz2dbs3y
+      eslint-config-xo-typescript: 0.53.0_5dhoj3dyh47mytths5oos3wciq
       eslint-import-resolver-typescript: 3.5.2_ktrec6dplf4now6nlbc6d67jee
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.28.0
       eslint-plugin-import: 2.26.0_mr6zxbuutkux4cnk246i23ue5a
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.28.0
-      eslint-plugin-prettier: 4.2.1_pgxuib4rd7wiymfktharf5ydt4
+      eslint-plugin-prettier: 4.2.1_wu6sbpjwlmhzr6hyelitt25ipy
       eslint-plugin-promise: 6.1.1_eslint@8.28.0
       eslint-plugin-sql: 2.1.0_eslint@8.28.0
       eslint-plugin-unicorn: 43.0.2_eslint@8.28.0
       eslint-plugin-unused-imports: 2.0.0_pieg3dxukybtqesa53urid6yfq
-      prettier: 2.7.1
+      prettier: 2.8.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -391,13 +391,13 @@ packages:
       lodash.orderby: 4.6.0
       lodash.pick: 4.4.0
 
-  /@silverhand/ts-config/1.2.1_typescript@4.9.3:
+  /@silverhand/ts-config/1.2.1_typescript@4.9.5:
     resolution: {integrity: sha512-Lm5Ydb45qKmXvlOfQfSb+1WHrdL5IBtzt+AMOR5h528H073FLzaazLiaDo4noBVT9PAVtO7kG9qjwSPzHf0k9Q==}
     engines: {node: ^16.0.0 || ^18.0.0}
     peerDependencies:
       typescript: ^4.7.4
     dependencies:
-      typescript: 4.9.3
+      typescript: 4.9.5
     dev: true
 
   /@sinonjs/commons/1.8.5:
@@ -593,7 +593,7 @@ packages:
       '@types/superagent': 4.1.16
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.40.1_5foadabyhuofbj4bdrxjdavre4:
+  /@typescript-eslint/eslint-plugin/5.40.1_fscm445b3jy5afr2mxu53wdtbu:
     resolution: {integrity: sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -604,22 +604,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       '@typescript-eslint/scope-manager': 5.40.1
-      '@typescript-eslint/type-utils': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
-      '@typescript-eslint/utils': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/type-utils': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
+      '@typescript-eslint/utils': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       debug: 4.3.4
       eslint: 8.28.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.40.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/parser/5.40.1_pku7h6lsbnh7tcsfjudlqd5qce:
     resolution: {integrity: sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -631,10 +631,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.40.1
       '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.5
       debug: 4.3.4
       eslint: 8.28.0
-      typescript: 4.9.3
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -647,7 +647,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.40.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.40.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/type-utils/5.40.1_pku7h6lsbnh7tcsfjudlqd5qce:
     resolution: {integrity: sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -657,12 +657,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.3
-      '@typescript-eslint/utils': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.5
+      '@typescript-eslint/utils': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       debug: 4.3.4
       eslint: 8.28.0
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -672,7 +672,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.40.1_typescript@4.9.3:
+  /@typescript-eslint/typescript-estree/5.40.1_typescript@4.9.5:
     resolution: {integrity: sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -687,13 +687,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.40.1_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/utils/5.40.1_pku7h6lsbnh7tcsfjudlqd5qce:
     resolution: {integrity: sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -703,7 +703,7 @@ packages:
       '@types/semver': 7.3.12
       '@typescript-eslint/scope-manager': 5.40.1
       '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.9.5
       eslint: 8.28.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.28.0
@@ -1307,7 +1307,7 @@ packages:
       eslint: 8.28.0
     dev: true
 
-  /eslint-config-xo-typescript/0.53.0_hfd344ics4i2ms5ixiwz2dbs3y:
+  /eslint-config-xo-typescript/0.53.0_5dhoj3dyh47mytths5oos3wciq:
     resolution: {integrity: sha512-IJ1n70egMPTou/41HoGGFbLf/2WCsVW5lSUxOSklrR8T1221fMRPVJxIVZ3evr8R+N5wR6uzg/0uzSymwWA5Bg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -1316,10 +1316,10 @@ packages:
       eslint: '>=8.0.0'
       typescript: '>=4.4'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.40.1_5foadabyhuofbj4bdrxjdavre4
-      '@typescript-eslint/parser': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/eslint-plugin': 5.40.1_fscm445b3jy5afr2mxu53wdtbu
+      '@typescript-eslint/parser': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       eslint: 8.28.0
-      typescript: 4.9.3
+      typescript: 4.9.5
     dev: true
 
   /eslint-config-xo/0.42.0_eslint@8.28.0:
@@ -1382,7 +1382,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       debug: 3.2.7
       eslint: 8.28.0
       eslint-import-resolver-node: 0.3.6
@@ -1431,7 +1431,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.40.1_pku7h6lsbnh7tcsfjudlqd5qce
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -1477,7 +1477,7 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-prettier/4.2.1_pgxuib4rd7wiymfktharf5ydt4:
+  /eslint-plugin-prettier/4.2.1_wu6sbpjwlmhzr6hyelitt25ipy:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1490,7 +1490,7 @@ packages:
     dependencies:
       eslint: 8.28.0
       eslint-config-prettier: 8.5.0_eslint@8.28.0
-      prettier: 2.7.1
+      prettier: 2.8.4
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -1552,7 +1552,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.40.1_5foadabyhuofbj4bdrxjdavre4
+      '@typescript-eslint/eslint-plugin': 5.40.1_fscm445b3jy5afr2mxu53wdtbu
       eslint: 8.28.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -2999,8 +2999,8 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+  /prettier/2.8.4:
+    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -3576,14 +3576,14 @@ packages:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.9.3:
+  /tsutils/3.21.0_typescript@4.9.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.3
+      typescript: 4.9.5
     dev: true
 
   /type-check/0.4.0:
@@ -3621,8 +3621,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript/4.9.3:
-    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
use pure index signature inference to allow force override:

```ts
Model.create(`
  create table forms (
    foo varchar(32) not null
  );`
)
  .extend('foo', z.string().optional());
```

then `foo` should be optional. this is useful when setting the field via a trigger.