### PR TITLE
feat(server): support response stream

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,8 +25,8 @@
     "dev": "pnpm build --watch --preserveWatchOutput --incremental",
     "dev:test": "pnpm build --sourcemap && pnpm test",
     "lint": "eslint src/",
-    "test": "c8 node --test | tap-arc",
-    "test:only": "node --test | tap-arc"
+    "test": "c8 --all node --test | tap-arc",
+    "test:only": "node --test"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/packages/server/src/adapter/koa.ts
+++ b/packages/server/src/adapter/koa.ts
@@ -33,7 +33,7 @@ export default function koaAdapter<OutputContext extends RequestContext>(
       .and(middleware)(
       {},
       async (context) => {
-        if (context.status) {
+        if (context.status && context.status !== 'ignore') {
           ctx.status = context.status;
         }
 

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -1,12 +1,15 @@
-import type { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'http';
+import type { ReadStream } from 'node:fs';
+import type { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'node:http';
 
 export type BaseContext = {
   /** A dictionary to put request info. Use `withRequest()` and `withBody()` to set it automatically. */
   request?: Record<string, unknown>;
-  /** The response status number. Default to 404. */
-  status?: number;
+  /** The response status number. Use `ignore` to skip status assignment. */
+  status?: number | 'ignore';
   /** The response json object. */
   json?: unknown;
+  /** The response stream. */
+  stream?: ReadStream;
   /** The response (outgoing) headers */
   headers?: OutgoingHttpHeaders;
 };

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -1,4 +1,3 @@
-import type { ReadStream } from 'node:fs';
 import type { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from 'node:http';
 
 export type BaseContext = {
@@ -8,8 +7,8 @@ export type BaseContext = {
   status?: number | 'ignore';
   /** The response json object. */
   json?: unknown;
-  /** The response stream. */
-  stream?: ReadStream;
+  /** The stream to write to the response. */
+  stream?: NodeJS.ReadableStream;
   /** The response (outgoing) headers */
   headers?: OutgoingHttpHeaders;
 };

--- a/packages/server/src/preset.test.ts
+++ b/packages/server/src/preset.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { createComposer } from './preset.js';
+
+describe('presets', () => {
+  it('should be able to create preset composer without error', async () => {
+    const preset = createComposer();
+    assert.ok(Array.isArray(preset.functions));
+    assert.ok(typeof preset.and === 'function');
+  });
+});

--- a/packages/server/src/response.test.ts
+++ b/packages/server/src/response.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { Readable } from 'node:stream';
 import { describe, it } from 'node:test';
 
 import { contentTypes } from '@withtyped/shared';
@@ -13,6 +14,13 @@ describe('writeContextToResponse()', () => {
     await writeContextToResponse(response, { status: 302, headers: { 'content-type': 'foo' } });
     assert.strictEqual(response.statusCode, 302);
     assert.strictEqual(response.getHeader('content-type'), 'foo');
+  });
+
+  it('should not set status code when `code` is explicitly ignored by user', async () => {
+    const { response } = createHttpContext();
+
+    await writeContextToResponse(response, { status: 'ignore' });
+    assert.strictEqual(response.statusCode, 200);
   });
 
   it('should automatically set content-type header when json is not null', async () => {
@@ -37,6 +45,20 @@ describe('writeContextToResponse()', () => {
     assert.strictEqual(response.statusCode, 200);
     assert.strictEqual(response.getHeader('content-type'), 'bar');
     assert.ok(stub.calledOnceWith(JSON.stringify({ foo: 123 }), 'utf8'));
+  });
+
+  it('should be ok when `stream` is set', async () => {
+    const { response } = createHttpContext();
+
+    // It is hard to test ServerResponse output with an empty IncomingMessage. Just do the sanity check here.
+    assert.ok(writeContextToResponse(response, { stream: Readable.from('foo') }));
+  });
+
+  it('should be ok when nothing is set', async () => {
+    const { response } = createHttpContext();
+
+    await writeContextToResponse(response, {});
+    assert.strictEqual(response.statusCode, 404);
   });
 });
 

--- a/packages/server/src/response.ts
+++ b/packages/server/src/response.ts
@@ -1,12 +1,10 @@
-import type { ServerResponse } from 'http';
+import type { ServerResponse } from 'node:http';
+import { pipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
-import stream from 'stream';
 
 import { contentTypes } from '@withtyped/shared';
 
 import type { BaseContext } from './middleware.js';
-
-const pipeline = promisify(stream.pipeline);
 
 // Need `null` to make callback be compatible with `promisify()`
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
- support `ReadStream` for response output
- support `'ignore'` for `status` for not setting status in the end