### PR TITLE
fix(server): model improvements

### DIFF
--- a/.changeset/poor-kings-jam.md
+++ b/.changeset/poor-kings-jam.md
@@ -1,0 +1,10 @@
+---
+"@withtyped/server": patch
+---
+
+Model improvements
+
+- Correct guard Zod types.
+- Supports setting readonly when there is a database default value available.
+- Use partial override for extend configs instead of replace.
+- Add `.guard()` alias for `.getGuard()`.

--- a/packages/server/src/model/index.test.ts
+++ b/packages/server/src/model/index.test.ts
@@ -49,18 +49,21 @@ describe('Model class', () => {
       createdAt: 'created_at',
     });
 
-    assert.deepStrictEqual(
-      forms.parse(
-        { id: 'foo', headers: {}, data: { foo: 'foo', bar: 1 }, test: [], toExclude: 'ok' },
-        'patch'
-      ),
-      {
-        id: 'foo',
-        headers: {},
-        data: { foo: 'foo', bar: 1 },
-        test: [],
-      }
-    );
+    const parse1 = Object.freeze({
+      id: 'foo',
+      headers: {},
+      data: { foo: 'foo', bar: 1 },
+      test: [],
+      toExclude: 'ok',
+    });
+    const expect1 = Object.freeze({
+      id: 'foo',
+      headers: {},
+      data: { foo: 'foo', bar: 1 },
+      test: [],
+    });
+    assert.deepStrictEqual(forms.parse(parse1, 'patch'), expect1);
+    assert.deepStrictEqual(forms.getGuard('patch').parse(parse1), expect1);
 
     assert.deepStrictEqual(forms.parse({ ...baseData, headers: { bar: 'foo' } }, 'patch'), {
       id: 'foo',
@@ -69,7 +72,8 @@ describe('Model class', () => {
       data2: null,
     });
 
-    assert.deepStrictEqual(forms.parse({ ...baseData, remoteAddress: null }, 'create'), {
+    const parse2 = Object.freeze({ ...baseData, remoteAddress: null });
+    const expect2 = Object.freeze({
       id: 'foo',
       remoteAddress: null,
       headers: {},
@@ -78,26 +82,29 @@ describe('Model class', () => {
       num: [1, 2, 3],
       test: [2, 3, 4],
     });
+    assert.deepStrictEqual(forms.parse(parse2, 'create'), expect2);
+    assert.deepStrictEqual(forms.guard('create').parse(parse2), expect2);
 
-    assert.deepStrictEqual(
-      forms.parse({
-        ...baseData,
-        remote_address: null,
-        num: null,
-        test: [456, 789],
-        created_at: new Date(123_123_123),
-      }),
-      {
-        id: 'foo',
-        remoteAddress: null,
-        headers: {},
-        data: { foo: 'foo', bar: 1 },
-        data2: null,
-        num: null,
-        test: [456, 789],
-        createdAt: new Date(123_123_123),
-      }
-    );
+    const parse3 = Object.freeze({
+      ...baseData,
+      remote_address: null,
+      num: null,
+      test: [456, 789],
+      created_at: new Date(123_123_123),
+    });
+    const expect3 = Object.freeze({
+      id: 'foo',
+      remoteAddress: null,
+      headers: {},
+      data: { foo: 'foo', bar: 1 },
+      data2: null,
+      num: null,
+      test: [456, 789],
+      createdAt: new Date(123_123_123),
+    });
+    assert.deepStrictEqual(forms.parse(parse3), expect3);
+    // The raw guard does not transform key cases, only `.parse()` does
+    assert.throws(() => forms.guard().parse(parse3), ZodError);
     assert.throws(() => forms.parse({ ...baseData, remote_address: 123 }), ZodError);
     assert.throws(() => forms.parse({ ...baseData, headers: undefined }), ZodError);
     assert.throws(

--- a/packages/server/src/model/index.ts
+++ b/packages/server/src/model/index.ts
@@ -154,7 +154,7 @@ export default class Model<
         ...this.extendedConfigs,
         [key]: {
           ...this.extendedConfigs[key],
-          ...(config instanceof z.ZodType<Type> ? { parser: config } : config),
+          ...(config instanceof z.ZodType ? { parser: config } : config),
         },
       }),
       this.excludedKeys
@@ -174,6 +174,14 @@ export default class Model<
   }
 
   /**
+   * Get the 'model' zod guard of the current model.
+   *
+   * @see {@link convertConfigToZod} For details of model guards.
+   */
+  getGuard<ForType extends ModelParseType = 'model'>(): ModelZodObject<
+    ModelParseReturnType<ModelType, DefaultKeys, ReadonlyKeys>[ForType]
+  >;
+  /**
    * Get the related zod guard of the current model.
    *
    * @param forType One of 'model' (default), 'create', or 'patch'.
@@ -181,6 +189,9 @@ export default class Model<
    * @see {@link InferModelPatch} For what will be transformed for a patch type guard.
    * @see {@link convertConfigToZod} For details of model guards.
    */
+  getGuard<ForType extends ModelParseType>(
+    forType: ForType
+  ): ModelZodObject<ModelParseReturnType<ModelType, DefaultKeys, ReadonlyKeys>[ForType]>;
   getGuard<ForType extends ModelParseType = 'model'>(
     forType?: ForType
   ): ModelZodObject<ModelParseReturnType<ModelType, DefaultKeys, ReadonlyKeys>[ForType]> {
@@ -208,6 +219,14 @@ export default class Model<
   }
 
   /**
+   * Parse the given data using the 'model' guard. Kebab-case and snake_case fields will be camelCased.
+   *
+   * @param data The data to parse.
+   * @see {@link convertConfigToZod} For details of model guards.
+   * @throws `ZodError` when parse failed.
+   */
+  parse(data: unknown): ModelParseReturnType<ModelType, DefaultKeys, ReadonlyKeys>['model'];
+  /**
    * Parse the given data using a designated model guard. Kebab-case and snake_case fields will be camelCased.
    *
    * @param data The data to parse.
@@ -217,6 +236,10 @@ export default class Model<
    * @see {@link convertConfigToZod} For details of model guards.
    * @throws `ZodError` when parse failed.
    */
+  parse<ForType extends ModelParseType>(
+    data: unknown,
+    forType: ForType
+  ): ModelParseReturnType<ModelType, DefaultKeys, ReadonlyKeys>[ForType];
   parse<ForType extends ModelParseType = 'model'>(
     data: unknown,
     forType?: ForType

--- a/packages/server/src/model/types.ts
+++ b/packages/server/src/model/types.ts
@@ -138,9 +138,12 @@ export type ModelCreateType<
   ModelType,
   DefaultKeys extends keyof ModelType,
   ReadonlyKeys extends keyof ModelType = never
-> = Omit<ModelType, ReadonlyKeys | DefaultKeys> & {
-  [key in DefaultKeys]?: ModelType[key];
-} & Record<ReadonlyKeys, undefined>;
+> = Omit<
+  Omit<ModelType, DefaultKeys> & {
+    [key in DefaultKeys]?: ModelType[key];
+  },
+  ReadonlyKeys
+>;
 
 export type ModelParseType = 'model' | 'create' | 'patch';
 export type ModelParseReturnType<


### PR DESCRIPTION
Model improvements

- Correct guard Zod types.
- Supports setting readonly when there is a database default value available.
- Use partial override for extend configs instead of replace.
- Add `.guard()` alias for `.getGuard()`.