### PR TITLE
fix(server): fix required zod type

### DIFF
--- a/.changeset/old-pants-pretend.md
+++ b/.changeset/old-pants-pretend.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/server": patch
+---
+
+fix `.required()` Zod type

--- a/packages/server/src/model/index.ts
+++ b/packages/server/src/model/index.ts
@@ -20,7 +20,10 @@ import { convertConfigToZod } from './utils.zod.js';
 export type ModelZodObject<M> = z.ZodObject<{
   // Without the `-?` here Zod will infer those optional key types
   // to `unknown` which is unexpected.
-  [Key in keyof M]-?: z.ZodType<M[Key]>;
+  [Key in keyof M]-?: undefined extends M[Key]
+    ? // Explicitly use `ZodOptional` since it's needed for `.required()` to recognize optional fields
+      z.ZodOptional<z.ZodType<Exclude<M[Key], undefined>>>
+    : z.ZodType<M[Key]>;
 }>;
 
 export default class Model<


### PR DESCRIPTION
Zod leverages `ZodOptional` for the return type of `.required()`. Explicitly use it to fix the unexpected type result of `.required()`.

<img width="299" alt="image" src="https://github.com/withtyped/withtyped/assets/14722250/2afd0e3b-3734-4e05-9ab3-089f0f1fc089">

while `deoptional` is

```ts
export declare type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U> ? deoptional<U> : T extends ZodNullable<infer U> ? ZodNullable<deoptional<U>> : T;
```