### PR TITLE
fix(client): fix Client types

### DIFF
--- a/.changeset/ninety-gorillas-roll.md
+++ b/.changeset/ninety-gorillas-roll.md
@@ -1,0 +1,9 @@
+---
+"@withtyped/client": patch
+---
+
+fix Client types
+
+- Use `any` for Client router context inference to avoid context conflict
+  - E.g. a router with `AuthContext` will not be able to use its type in the Client generic
+- Support Promise build in `headers` config

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -104,6 +104,23 @@ describe('Client', () => {
     );
   });
 
+  it('should send with dynamic promise custom headers', async () => {
+    const client = new Client<typeof router>({
+      baseUrl,
+      headers: async (url, method) => ({ foo: url.pathname, bar: method }),
+    });
+
+    await client.get('/books');
+
+    assert.ok(
+      fakeFetch.calledOnceWith(withPath('/books'), {
+        method: RequestMethod.GET,
+        headers: { host: baseUrl.host, accept: contentTypes.json, foo: '/books', bar: 'get' },
+        body: undefined,
+      })
+    );
+  });
+
   it('should throw when path is not string', async () => {
     const client = new Client<typeof router>(baseUrl);
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -45,7 +45,9 @@ type CanBePromise<T extends (...args: any[]) => any> =
 
 export type HeadersOption =
   | Record<string, string>
-  | CanBePromise<(url: URL, method: Lowercase<RequestMethod>) => Record<string, string>>;
+  | CanBePromise<
+      (url: URL, method: Lowercase<RequestMethod>) => Record<string, string> | undefined
+    >;
 
 export type ClientConfig = {
   baseUrl: URL;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -7,6 +7,10 @@ export type ClientPayload = {
   body?: unknown;
 };
 
+/**
+ * Infer the routes type of a router. The result will be `never` if a non-router type is given.
+ * @see {@link Router}
+ */
 export type RouterRoutes<RouterInstance extends Router> = RouterInstance extends Router<
   infer _,
   infer Routes,
@@ -33,20 +37,26 @@ export type RouterClient<Routes extends BaseRoutes> = {
   [key in Lowercase<RequestMethod>]: ClientRequestHandler<Routes[key]>;
 };
 
+// Use `any` here for compatibility. The final type can be correctly inferred.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CanBePromise<T extends (...args: any[]) => any> =
+  | T
+  | ((...args: Parameters<T>) => Promise<ReturnType<T>>);
+
+export type HeadersOption =
+  | Record<string, string>
+  | CanBePromise<(url: URL, method: Lowercase<RequestMethod>) => Record<string, string>>;
+
 export type ClientConfig = {
   baseUrl: URL;
-  headers?:
-    | Record<string, string>
-    | ((url: URL, method: Lowercase<RequestMethod>) => Record<string, string>);
+  headers?: HeadersOption;
 };
 
 export type ClientConfigInit = {
   /** Base URL to prepend for every request. Only origin and pathname will be applied. */
   baseUrl: string | URL;
   /** Additional headers to append for every request, also accepts a function that returns headers. */
-  headers?:
-    | Record<string, string>
-    | ((url: URL, method: Lowercase<RequestMethod>) => Record<string, string>);
+  headers?: HeadersOption;
 };
 
 export { RequestMethod } from '@withtyped/shared';

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -21,3 +21,11 @@ export const tryJson = async (response: Response) => {
     return await response.json();
   } catch {}
 };
+
+// Copied from `@silverhand/essentials`
+// Use this implementation over `node:util/types` to recognize non-native promises.
+export const isPromise = (value: unknown): value is Promise<unknown> =>
+  value !== null &&
+  (typeof value === 'object' || typeof value === 'function') &&
+  'then' in value &&
+  typeof value.then === 'function';


### PR DESCRIPTION
- Use `any` for Client router context inference to avoid context conflict
  - E.g. a router with `AuthContext` will not be able to use its type in the Client generic
- Support Promise build in `headers` config
