### PR TITLE
refactor(client): loose RouterRoutes generic input

### DIFF
--- a/.changeset/fluffy-candles-shave.md
+++ b/.changeset/fluffy-candles-shave.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/client": patch
+---
+
+loose RouterRoutes generic input to avoid type conflict

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -11,7 +11,7 @@ export type ClientPayload = {
  * Infer the routes type of a router. The result will be `never` if a non-router type is given.
  * @see {@link Router}
  */
-export type RouterRoutes<RouterInstance extends Router> = RouterInstance extends Router<
+export type RouterRoutes<RouterInstance> = RouterInstance extends Router<
   infer _,
   infer Routes,
   string


### PR DESCRIPTION
restricting the generic input will potentially result the type incompatibility issue:

<img width="686" alt="image" src="https://github.com/withtyped/withtyped/assets/14722250/bc967d77-54fc-4537-84e4-139252d8ef93">

loose it can resolve the issue while keeping the same effect.