### PR TITLE
fix(server): allow multiple items in `content-type` header

### DIFF
--- a/.changeset/tidy-rivers-hide.md
+++ b/.changeset/tidy-rivers-hide.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/server": patch
+---
+
+Allow multiple items in `content-type` header

--- a/packages/server/src/middleware/with-body.test.ts
+++ b/packages/server/src/middleware/with-body.test.ts
@@ -109,6 +109,27 @@ describe('withBody()', () => {
     await promise;
   });
 
+  it('should read JSON string and convert to object for content-type with multiple items', async () => {
+    const httpContext = createHttpContext();
+    const raw = '{     "foo": "bar",|   \n  "baz": 1,| \n\n"bar": [true,| false]}';
+    const stringArray = raw.split('|');
+
+    const promise = run(
+      { ...mockContext, headers: { 'content-type': `${contentTypes.json}; charset=utf-8` } },
+      async (context) => {
+        assert.deepStrictEqual(context.request.body, JSON.parse(stringArray.join('')));
+      },
+      httpContext
+    );
+
+    for (const value of stringArray) {
+      httpContext.request.emit('data', Buffer.from(value));
+    }
+
+    httpContext.request.emit('end');
+    await promise;
+  });
+
   it('should throw error when request received an error event', async () => {
     const testError = new Error('test');
     const httpContext = createHttpContext();

--- a/packages/server/src/middleware/with-body.ts
+++ b/packages/server/src/middleware/with-body.ts
@@ -63,7 +63,11 @@ export default function withBody<InputContext extends RequestContext>() {
       return next(context as WithBodyContext<InputContext>);
     }
 
-    if (context.request.headers['content-type'] !== contentTypes.json) {
+    if (
+      context.request.headers['content-type']
+        ?.split(';')
+        .every((value) => value.trim() !== contentTypes.json)
+    ) {
       throw new RequestError(
         `Unexpected \`content-type\` header, only accept "${contentTypes.json}"`,
         400


### PR DESCRIPTION
should be able to parse `application/json; charset=utf-8`