### PR TITLE
feat(server): add `bodyRaw` buffer to context in `withBody()`

### DIFF
--- a/.changeset/quiet-phones-reply.md
+++ b/.changeset/quiet-phones-reply.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/server": patch
+---
+
+Add `bodyRaw` buffer to context in `withBody()`

--- a/packages/server/src/middleware/with-body.test.ts
+++ b/packages/server/src/middleware/with-body.test.ts
@@ -97,6 +97,7 @@ describe('withBody()', () => {
       mockContext,
       async (context) => {
         assert.deepStrictEqual(context.request.body, JSON.parse(stringArray.join('')));
+        assert.deepStrictEqual(context.request.bodyRaw, Buffer.from(stringArray.join('')));
       },
       httpContext
     );
@@ -118,6 +119,7 @@ describe('withBody()', () => {
       { ...mockContext, headers: { 'content-type': `${contentTypes.json}; charset=utf-8` } },
       async (context) => {
         assert.deepStrictEqual(context.request.body, JSON.parse(stringArray.join('')));
+        assert.deepStrictEqual(context.request.bodyRaw, Buffer.from(stringArray.join('')));
       },
       httpContext
     );
@@ -154,6 +156,7 @@ describe('withBody()', () => {
       async (context) => {
         // eslint-disable-next-line unicorn/no-useless-undefined
         assert.deepStrictEqual(context.request.body, undefined);
+        assert.deepStrictEqual(context.request.bodyRaw, Buffer.from(stringArray.join('')));
       },
       httpContext
     );

--- a/packages/server/src/middleware/with-body.ts
+++ b/packages/server/src/middleware/with-body.ts
@@ -8,7 +8,7 @@ import type { MergeRequestContext, RequestContext } from './with-request.js';
 
 export type WithBodyContext<InputContext extends RequestContext> = MergeRequestContext<
   InputContext,
-  { body?: Json }
+  { body?: Json; bodyRaw?: Buffer }
 >;
 
 const tryParse = (body: string): Json | undefined => {
@@ -74,6 +74,9 @@ export default function withBody<InputContext extends RequestContext>() {
       );
     }
 
-    return next({ ...context, request: { ...context.request, body: tryParse(rawString) } });
+    return next({
+      ...context,
+      request: { ...context.request, body: tryParse(rawString), bodyRaw: raw },
+    });
   };
 }


### PR DESCRIPTION
append `bodyRaw` buffer to body for more flexibility