### PR TITLE
feat(server): allow multiple middleware functions in routes

### DIFF
--- a/.changeset/thirty-pants-hug.md
+++ b/.changeset/thirty-pants-hug.md
@@ -1,0 +1,8 @@
+---
+"@withtyped/postgres": patch
+"@withtyped/client": patch
+"@withtyped/server": patch
+"@withtyped/shared": patch
+---
+
+Allow multiple middleware functions in routes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,8 +26,8 @@
     "dev": "pnpm build --watch --preserveWatchOutput --incremental",
     "dev:test": "pnpm build --sourcemap && pnpm test",
     "lint": "eslint src/",
-    "test": "c8 node --test | tap-arc",
-    "test:only": "node --test | tap-arc"
+    "test": "c8 node --test",
+    "test:only": "node --test"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^3.0.0",
@@ -39,7 +39,6 @@
     "lint-staged": "^13.0.4",
     "prettier": "^2.8.4",
     "sinon": "^14.0.2",
-    "tap-arc": "^0.3.5",
     "typescript": "^5.1.0",
     "zod": "^3.19.1"
   },

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -26,7 +26,7 @@
     "dev": "pnpm build --watch --preserveWatchOutput --incremental",
     "dev:test": "pnpm build --sourcemap && pnpm test",
     "lint": "eslint src/",
-    "test": "c8 node --test | tap-arc",
+    "test": "c8 node --test",
     "test:only": "node --test"
   },
   "devDependencies": {
@@ -40,7 +40,6 @@
     "lint-staged": "^13.0.4",
     "prettier": "^2.8.4",
     "sinon": "^14.0.2",
-    "tap-arc": "^0.3.5",
     "typescript": "^5.1.0",
     "zod": "^3.19.1"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,7 +30,7 @@
     "dev": "pnpm build --watch --preserveWatchOutput --incremental",
     "dev:test": "pnpm build --sourcemap && pnpm test",
     "lint": "eslint src/",
-    "test": "c8 --all node --test | tap-arc",
+    "test": "c8 --all node --test",
     "test:only": "node --test"
   },
   "devDependencies": {
@@ -47,7 +47,6 @@
     "prettier": "^2.8.4",
     "sinon": "^14.0.2",
     "supertest": "^6.3.2",
-    "tap-arc": "^0.3.5",
     "typescript": "^5.1.0",
     "zod": "^3.19.1"
   },

--- a/packages/server/src/compose.ts
+++ b/packages/server/src/compose.ts
@@ -65,7 +65,7 @@ const buildNext = (
  * @param functions An array of (supposed to be) middleware functions.
  * @returns A composer with the given functions.
  */
-const createComposer = function <
+export const createComposer = function <
   T extends unknown[],
   InputContext extends BaseContext,
   OutputContext extends BaseContext

--- a/packages/server/src/router/types.build-route.ts
+++ b/packages/server/src/router/types.build-route.ts
@@ -1,0 +1,180 @@
+import type { RequestMethod } from '@withtyped/shared';
+
+import type { RequestContext } from '../middleware/with-request.js';
+import type { BaseContext, MiddlewareFunction } from '../middleware.js';
+
+import type Router from './index.js';
+import type { BaseRoutes, GuardedContext, Normalized, PathGuard, RequestGuard } from './types.js';
+
+export type RouterWithRoute<
+  InputContext extends RequestContext,
+  Routes extends BaseRoutes,
+  Prefix extends string,
+  Method extends Lowercase<RequestMethod>,
+  Path extends string,
+  Search,
+  Body,
+  JsonResponse
+> = Router<
+  InputContext,
+  {
+    [method in Lowercase<RequestMethod>]: method extends Method
+      ? Routes[method] & {
+          [path in Path as Normalized<`${Prefix}${Path}`>]: PathGuard<
+            Path,
+            Search,
+            Body,
+            JsonResponse
+          >;
+        }
+      : Routes[method];
+  },
+  Prefix
+>;
+
+/**
+ * Due to TypeScript limitations, we can't use a generic middleware function array
+ * for the `run` parameter of `buildRoute`. Instead, we have to overload the
+ * function for each number of middleware functions.
+ */
+export type BuildRoute<
+  InputContext extends RequestContext,
+  Routes extends BaseRoutes,
+  Prefix extends string,
+  Method extends Lowercase<RequestMethod>
+> = {
+  <Path extends string, Search, Body, JsonResponse>(
+    path: Path extends Normalized<Path> ? Path : never,
+    guard: RequestGuard<Search, Body, JsonResponse>,
+    run: MiddlewareFunction<
+      GuardedContext<InputContext, Path extends Normalized<Path> ? Path : never, Search, Body>,
+      InputContext & {
+        json?: JsonResponse;
+      }
+    >
+  ): RouterWithRoute<
+    InputContext,
+    Routes,
+    Prefix,
+    Method,
+    Normalized<Path>,
+    Search,
+    Body,
+    JsonResponse
+  >;
+  <Path extends string, Search, Body, JsonResponse, C1 extends BaseContext>(
+    path: Path extends Normalized<Path> ? Path : never,
+    guard: RequestGuard<Search, Body, JsonResponse>,
+    run_1: MiddlewareFunction<
+      GuardedContext<InputContext, Path extends Normalized<Path> ? Path : never, Search, Body>,
+      C1
+    >,
+    run_2: MiddlewareFunction<
+      C1,
+      InputContext & {
+        json?: JsonResponse;
+      }
+    >
+  ): RouterWithRoute<
+    InputContext,
+    Routes,
+    Prefix,
+    Method,
+    Normalized<Path>,
+    Search,
+    Body,
+    JsonResponse
+  >;
+  <Path extends string, Search, Body, JsonResponse, C1 extends BaseContext, C2 extends BaseContext>(
+    path: Path extends Normalized<Path> ? Path : never,
+    guard: RequestGuard<Search, Body, JsonResponse>,
+    run_1: MiddlewareFunction<
+      GuardedContext<InputContext, Path extends Normalized<Path> ? Path : never, Search, Body>,
+      C1
+    >,
+    run_2: MiddlewareFunction<C1, C2>,
+    run_3: MiddlewareFunction<
+      C2,
+      InputContext & {
+        json?: JsonResponse;
+      }
+    >
+  ): RouterWithRoute<
+    InputContext,
+    Routes,
+    Prefix,
+    Method,
+    Normalized<Path>,
+    Search,
+    Body,
+    JsonResponse
+  >;
+  <
+    Path extends string,
+    Search,
+    Body,
+    JsonResponse,
+    C1 extends BaseContext,
+    C2 extends BaseContext,
+    C3 extends BaseContext
+  >(
+    path: Path extends Normalized<Path> ? Path : never,
+    guard: RequestGuard<Search, Body, JsonResponse>,
+    run_1: MiddlewareFunction<
+      GuardedContext<InputContext, Path extends Normalized<Path> ? Path : never, Search, Body>,
+      C1
+    >,
+    run_2: MiddlewareFunction<C1, C2>,
+    run_3: MiddlewareFunction<C2, C3>,
+    run_4: MiddlewareFunction<
+      C3,
+      InputContext & {
+        json?: JsonResponse;
+      }
+    >
+  ): RouterWithRoute<
+    InputContext,
+    Routes,
+    Prefix,
+    Method,
+    Normalized<Path>,
+    Search,
+    Body,
+    JsonResponse
+  >;
+  <
+    Path extends string,
+    Search,
+    Body,
+    JsonResponse,
+    C1 extends BaseContext,
+    C2 extends BaseContext,
+    C3 extends BaseContext,
+    C4 extends BaseContext
+  >(
+    path: Path extends Normalized<Path> ? Path : never,
+    guard: RequestGuard<Search, Body, JsonResponse>,
+    run_1: MiddlewareFunction<
+      GuardedContext<InputContext, Path extends Normalized<Path> ? Path : never, Search, Body>,
+      C1
+    >,
+    run_2: MiddlewareFunction<C1, C2>,
+    run_3: MiddlewareFunction<C2, C3>,
+    run_4: MiddlewareFunction<C3, C4>,
+    run_5: MiddlewareFunction<
+      C4,
+      InputContext & {
+        json?: JsonResponse;
+      }
+    >
+  ): RouterWithRoute<
+    InputContext,
+    Routes,
+    Prefix,
+    Method,
+    Normalized<Path>,
+    Search,
+    Body,
+    JsonResponse
+  >;
+};

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,8 +26,8 @@
     "dev": "pnpm build --watch --preserveWatchOutput --incremental",
     "dev:test": "pnpm build --sourcemap && pnpm test",
     "lint": "eslint src/",
-    "test": "c8 node --test | tap-arc",
-    "test:only": "node --test | tap-arc"
+    "test": "c8 node --test",
+    "test:only": "node --test"
   },
   "devDependencies": {
     "@silverhand/eslint-config": "^3.0.0",
@@ -38,7 +38,6 @@
     "lint-staged": "^13.0.4",
     "prettier": "^2.8.4",
     "sinon": "^14.0.2",
-    "tap-arc": "^0.3.5",
     "typescript": "^5.1.0"
   },
   "eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       sinon:
         specifier: ^14.0.2
         version: 14.0.2
-      tap-arc:
-        specifier: ^0.3.5
-        version: 0.3.5
       typescript:
         specifier: ^5.1.0
         version: 5.1.3
@@ -158,9 +155,6 @@ importers:
       sinon:
         specifier: ^14.0.2
         version: 14.0.2
-      tap-arc:
-        specifier: ^0.3.5
-        version: 0.3.5
       typescript:
         specifier: ^5.1.0
         version: 5.1.3
@@ -262,9 +256,6 @@ importers:
       supertest:
         specifier: ^6.3.2
         version: 6.3.2
-      tap-arc:
-        specifier: ^0.3.5
-        version: 0.3.5
       typescript:
         specifier: ^5.1.0
         version: 5.1.3
@@ -298,9 +289,6 @@ importers:
       sinon:
         specifier: ^14.0.2
         version: 14.0.2
-      tap-arc:
-        specifier: ^0.3.5
-        version: 0.3.5
       typescript:
         specifier: ^5.1.0
         version: 5.1.3
@@ -1543,11 +1531,6 @@ packages:
       wrappy: 1.0.2
     dev: true
 
-  /diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-    dev: true
-
   /diff@5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
@@ -2088,10 +2071,6 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /events-to-array@1.1.2:
-    resolution: {integrity: sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA==}
     dev: true
 
   /execa@6.1.0:
@@ -2837,12 +2816,6 @@ packages:
       minimist: 1.2.7
     dev: true
 
-  /json5@2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
-
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
@@ -3104,13 +3077,6 @@ packages:
 
   /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
-    dev: true
-
-  /minipass@3.3.4:
-    resolution: {integrity: sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
     dev: true
 
   /mixme@0.5.5:
@@ -3678,6 +3644,7 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3802,6 +3769,7 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -4085,6 +4053,7 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
       safe-buffer: 5.2.1
+    dev: false
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -4177,46 +4146,9 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /tap-arc@0.3.5:
-    resolution: {integrity: sha512-uGqN8JM+BmBwJhfDwTtGVGyZ0HLxcoPJMzTqBHJjfKS4M6+CcKHS+PFJBhJoGtpBrpeMPBoLyLaP3zb8vsccOA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      json5: 2.2.1
-      minimist: 1.2.7
-      picocolors: 1.0.0
-      strip-ansi: 6.0.1
-      tap-parser: 11.0.2
-      tcompare: 5.0.7
-      through2: 4.0.2
-    dev: true
-
-  /tap-parser@11.0.2:
-    resolution: {integrity: sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==}
-    engines: {node: '>= 8'}
-    hasBin: true
-    dependencies:
-      events-to-array: 1.1.2
-      minipass: 3.3.4
-      tap-yaml: 1.0.2
-    dev: true
-
-  /tap-yaml@1.0.2:
-    resolution: {integrity: sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==}
-    dependencies:
-      yaml: 1.10.2
-    dev: true
-
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-    dev: true
-
-  /tcompare@5.0.7:
-    resolution: {integrity: sha512-d9iddt6YYGgyxJw5bjsN7UJUO1kGOtjSlNy/4PoGYAjQS5pAT/hzIoLf1bZCw+uUxRmZJh7Yy1aA7xKVRT9B4w==}
-    engines: {node: '>=10'}
-    dependencies:
-      diff: 4.0.2
     dev: true
 
   /term-size@2.2.1:
@@ -4248,6 +4180,7 @@ packages:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
     dependencies:
       readable-stream: 3.6.0
+    dev: false
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -4397,6 +4330,7 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
 
   /uuid-parse@1.1.0:
     resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
@@ -4525,11 +4459,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
-
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
     dev: true
 
   /yaml@2.1.3:


### PR DESCRIPTION
thus no need for `compose()` in routes, since explicitly using `compose()` brings type issues and make the route ugly