### PR TITLE
refactor: use global symbol registry

### DIFF
--- a/.changeset/curvy-hornets-roll.md
+++ b/.changeset/curvy-hornets-roll.md
@@ -1,0 +1,6 @@
+---
+"@withtyped/postgres": patch
+"@withtyped/server": patch
+---
+
+Use global Symbol registry to increase compatibility when multiple @withtyped libraries exist

--- a/packages/postgres/src/sql.test.ts
+++ b/packages/postgres/src/sql.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { idSymbolKeys, idSymbols } from '@withtyped/server';
 import Model from '@withtyped/server/model';
 import { normalizeString } from '@withtyped/shared';
 
@@ -97,6 +98,10 @@ it('should recognize model as identifiers with schema', () => {
     /* Sql */ `create table foo (id varchar(32) primary key not null, bar bigint);`,
     'baz'
   ).identifiable;
+
+  // @ts-expect-error Should be able to access the model's metadata by
+  // accessing the global symbol with the same key.
+  assert.strictEqual(foo[idSymbols.model], foo[Symbol.for(idSymbolKeys.model)]);
 
   const { raw, args } = sql`
     update ${foo}    

--- a/packages/server/src/identifiable/index.ts
+++ b/packages/server/src/identifiable/index.ts
@@ -2,33 +2,45 @@
 // classes cannot have dynamic index signatures.
 
 /**
+ * The global symbol keys used to identify identifiable types.
+ * Usually you don't need to use them directly.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry | MDN: Shared symbols in the global symbol registry}
+ */
+export const idSymbolKeys = Object.freeze({
+  model: '@withtyped/server/identifiable',
+  column: '@withtyped/server/identifiable.column',
+  updateColumn: '@withtyped/server/identifiable.update_column',
+} as const);
+
+/**
  * The symbol used to identify `IdentifiableModel` types. It should be used as
  * a property on the model object with the value of the model metadata.
  *
  * @see {@link IdentifiableModel}
  */
-const identifiableSymbol = Symbol('identifiable');
+const identifiableSymbol = Symbol.for(idSymbolKeys.model);
 /**
  * The symbol used to identify `IdentifiableColumn` types. It should be used as
  * a property on the column object with the value of `true`.
  *
  * @see {@link IdentifiableColumn}
  */
-const identifiableColumnSymbol = Symbol('identifiable.column');
+const identifiableColumnSymbol = Symbol.for(idSymbolKeys.column);
 /**
  * The symbol used to identify `IdentifiableUpdateColumn` types. It should be
  * used as a property on the column object with the value of `true`.
  *
  * @see {@link IdentifiableUpdateColumn}
  */
-const IdentifiableUpdateColumnSymbol = Symbol('identifiable.update_column');
+const IdentifiableUpdateColumnSymbol = Symbol.for(idSymbolKeys.updateColumn);
 
 /** The symbols used to identify identifiable types. */
-export const idSymbols = {
+export const idSymbols = Object.freeze({
   model: identifiableSymbol,
   column: identifiableColumnSymbol,
   updateColumn: IdentifiableUpdateColumnSymbol,
-} as const;
+} as const);
 
 export type IdentifiableModelMetadata = {
   /** The corresponding schema name in the database. */


### PR DESCRIPTION
Use global Symbol registry to increase compatibility when multiple @withtyped libraries exist.