### PR TITLE
fix(server): inherit model schema and fix model key types after exclude

### DIFF
--- a/.changeset/orange-lizards-approve.md
+++ b/.changeset/orange-lizards-approve.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/server": patch
+---
+
+Inherit model schema and fix model key types after `.exclude()`

--- a/packages/server/src/model/index.test.ts
+++ b/packages/server/src/model/index.test.ts
@@ -131,6 +131,23 @@ describe('Model class', () => {
     assert.throws(() => forms.guard('patch').parse({ id: 'baz', createdAt: new Date() }), ZodError);
   });
 
+  it('inherit schema after `.extend()` or `.exclude()`', () => {
+    const forms = Model.create(
+      /* Sql */ `
+      create table forms (
+        id VARCHAR(32) not null,
+        created_at timestamptz not null default(now())
+      );`,
+      'baz'
+    );
+    assert.deepStrictEqual(forms.schema, 'baz');
+    assert.deepStrictEqual(forms.exclude('createdAt').schema, 'baz');
+    assert.deepStrictEqual(
+      forms.exclude('createdAt').extend('id', { default: '1', readonly: true }).schema,
+      'baz'
+    );
+  });
+
   it('should throw error when table name is missing in query', () => {
     assert.throws(
       () =>

--- a/packages/server/src/model/index.ts
+++ b/packages/server/src/model/index.ts
@@ -97,11 +97,12 @@ export default class Model<
   public readonly rawKeys: Readonly<Record<keyof ModelType, string>>;
   protected readonly excludedKeySet: Set<string>;
 
+  /** @internal Use {@link create()} instead. */
   constructor(
     public readonly raw: string,
     public readonly extendedConfigs: Record<string, ModelExtendConfig<unknown>>,
     public readonly excludedKeys: string[],
-    public readonly schema?: string
+    public readonly schema: string | undefined
   ) {
     const tableName = parseTableName(raw);
 
@@ -278,7 +279,8 @@ export default class Model<
           ...(config instanceof z.ZodType ? { parser: config } : config),
         },
       }),
-      this.excludedKeys
+      this.excludedKeys,
+      this.schema
     );
   }
 
@@ -288,10 +290,10 @@ export default class Model<
   ): Model<
     Table,
     { [key in keyof ModelType as key extends Key ? never : key]: ModelType[key] },
-    DefaultKeys,
-    ReadonlyKeys
+    Exclude<DefaultKeys, Key>,
+    Exclude<ReadonlyKeys, Key>
   > {
-    return new Model(this.raw, this.extendedConfigs, this.excludedKeys.concat(key));
+    return new Model(this.raw, this.extendedConfigs, this.excludedKeys.concat(key), this.schema);
   }
 
   /**


### PR DESCRIPTION
- model schema should be kept after `.extend()` or `.exclude()`
- excluded keys should be also removed from default and readonly key types