### PR TITLE
feat: support general middleware

### DIFF
--- a/.changeset/gold-kiwis-tie.md
+++ b/.changeset/gold-kiwis-tie.md
@@ -1,0 +1,19 @@
+---
+"@withtyped/client": minor
+"@withtyped/server": minor
+---
+
+support general middleware
+
+Use route's `.use()` method to add a general middleware that will be executed for all requests to the route.
+
+```ts
+import { createRouter } from '@withtyped/server';
+
+const router = createRouter()
+  .use(async (context, next) => next({ ...context, foo: 'bar' }))
+  .get('/foo', async (context) => context.foo); // 'bar'
+```
+
+> [!Note]
+> The `.use()` call must be placed before the route's method call (e.g. `.get()`) for type clarity. If you place it after, an error will be thrown.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "typescriptreact",
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit"
   },
   "cSpell.words": [
     "pnpm",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,7 +23,7 @@ export class ResponseError extends Error {
 export default class Client<
   // Use `any` here to avoid context conflicts. The final type can be correctly inferred.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  R extends Router<any, BaseRoutes, string>,
+  R extends Router<any, any, BaseRoutes, string>,
   Routes extends BaseRoutes = RouterRoutes<R>
 > implements RouterClient<Routes>
 {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -22,6 +22,7 @@ export type ClientPayload = {
  */
 export type RouterRoutes<RouterInstance> = RouterInstance extends Router<
   infer _,
+  infer _,
   infer Routes,
   string
 >

--- a/packages/server/src/router/types.build-route.ts
+++ b/packages/server/src/router/types.build-route.ts
@@ -7,6 +7,7 @@ import type Router from './index.js';
 import type { BaseRoutes, GuardedContext, Normalized, PathGuard, RequestGuard } from './types.js';
 
 export type RouterWithRoute<
+  PreInputContext extends RequestContext,
   InputContext extends RequestContext,
   Routes extends BaseRoutes,
   Prefix extends string,
@@ -16,6 +17,7 @@ export type RouterWithRoute<
   Body,
   JsonResponse
 > = Router<
+  PreInputContext,
   InputContext,
   {
     [method in Lowercase<RequestMethod>]: method extends Method
@@ -38,6 +40,7 @@ export type RouterWithRoute<
  * function for each number of middleware functions.
  */
 export type BuildRoute<
+  PreInputContext extends RequestContext,
   InputContext extends RequestContext,
   Routes extends BaseRoutes,
   Prefix extends string,
@@ -53,6 +56,7 @@ export type BuildRoute<
       }
     >
   ): RouterWithRoute<
+    PreInputContext,
     InputContext,
     Routes,
     Prefix,
@@ -76,6 +80,7 @@ export type BuildRoute<
       }
     >
   ): RouterWithRoute<
+    PreInputContext,
     InputContext,
     Routes,
     Prefix,
@@ -100,6 +105,7 @@ export type BuildRoute<
       }
     >
   ): RouterWithRoute<
+    PreInputContext,
     InputContext,
     Routes,
     Prefix,
@@ -133,6 +139,7 @@ export type BuildRoute<
       }
     >
   ): RouterWithRoute<
+    PreInputContext,
     InputContext,
     Routes,
     Prefix,
@@ -168,6 +175,7 @@ export type BuildRoute<
       }
     >
   ): RouterWithRoute<
+    PreInputContext,
     InputContext,
     Routes,
     Prefix,


### PR DESCRIPTION
Use route's `.use()` method to add a general middleware that will be executed for all requests to the route.

```ts
import { createRouter } from '@withtyped/server';

const router = createRouter()
  .use(async (context, next) => next({ ...context, foo: 'bar' }))
  .get('/foo', async (context) => context.foo); // 'bar'
```