### PR TITLE
fix: bug fixes

### DIFF
--- a/.changeset/curvy-guests-design.md
+++ b/.changeset/curvy-guests-design.md
@@ -1,0 +1,5 @@
+---
+"@withtyped/server": patch
+---
+
+fix router `.pack()` type and respond with parsed json

--- a/.changeset/curvy-guests-design.md
+++ b/.changeset/curvy-guests-design.md
@@ -2,4 +2,6 @@
 "@withtyped/server": patch
 ---
 
-fix router `.pack()` type and respond with parsed json
+- fix router `.pack()` type, now the other router's type is `Router<InputContext, InputContext, AnotherRoutes, string>`
+- fix `CreateRouter` type, now it returns `Router<InputContext, InputContext>` when no prefix is provided
+- router handler now responds with the parsed json instead of the original object from the context

--- a/packages/server/src/router/index.test.ts
+++ b/packages/server/src/router/index.test.ts
@@ -109,6 +109,23 @@ describe('Router', () => {
     );
   });
 
+  it('should respond with parsed json when the route matches', async () => {
+    const router = new Router().get(
+      '/books',
+      { response: z.object({ foo: z.string() }) },
+      // @ts-expect-error for testing
+      async (context, next) => next({ ...context, json: { foo: 'bar', bar: 123 } })
+    );
+    await router.routes()(
+      createRequestContext(RequestMethod.GET, '/books'),
+      async (context) => {
+        assert.strictEqual(context.status, 200);
+        assert.deepStrictEqual(context.json, { foo: 'bar' });
+      },
+      createHttpContext()
+    );
+  });
+
   it('should not call general middleware functions when no route matches', async () => {
     const mid1 = sinon.fake(async (context, next) =>
       next({ ...context, foo: 'bar' })

--- a/packages/server/src/router/index.ts
+++ b/packages/server/src/router/index.ts
@@ -130,13 +130,15 @@ export default class Router<
           async (context) => {
             const responseGuard = route.guard.response;
 
-            if (responseGuard) {
-              responseGuard.parse(context.json);
-            } else if (route.path !== openApiRoute && context.json !== undefined) {
+            if (!responseGuard && route.path !== openApiRoute && context.json !== undefined) {
               throw new TypeError('Response guard is required when providing a response json.');
             }
 
-            return next({ ...context, status: context.status ?? (context.json ? 200 : 204) });
+            return next({
+              ...context,
+              json: responseGuard?.parse(context.json) ?? context.json,
+              status: context.status ?? (context.json ? 200 : 204),
+            });
           },
           http
         );

--- a/packages/server/src/router/index.ts
+++ b/packages/server/src/router/index.ts
@@ -240,7 +240,7 @@ export default class Router<
 }
 
 export type CreateRouter = {
-  <InputContext extends RequestContext>(): Router<InputContext>;
+  <InputContext extends RequestContext>(): Router<InputContext, InputContext>;
   <InputContext extends RequestContext, Prefix extends string>(
     prefix: NormalizedPrefix<Prefix>
   ): Router<InputContext, InputContext, BaseRoutes, NormalizedPrefix<Prefix>>;

--- a/packages/server/src/router/index.ts
+++ b/packages/server/src/router/index.ts
@@ -185,7 +185,7 @@ export default class Router<
   }
 
   public pack<AnotherRoutes extends BaseRoutes>(
-    another: Router<PreInputContext, InputContext, AnotherRoutes, string> // Don't care another prefix since routes are all prefixed
+    another: Router<InputContext, InputContext, AnotherRoutes, string> // Don't care another prefix since routes are all prefixed
   ): Router<
     PreInputContext,
     InputContext,


### PR DESCRIPTION
- fix router `.pack()` type, now the other router's type is `Router<InputContext, InputContext, AnotherRoutes, string>`
- fix `CreateRouter` type, now it returns `Router<InputContext, InputContext>` when no prefix is provided
- router handler now responds with the parsed json instead of the original object from the context
